### PR TITLE
Add qty and expireAfter properties to PrintJob

### DIFF
--- a/src/PrintNode/PrintJob.php
+++ b/src/PrintNode/PrintJob.php
@@ -14,6 +14,9 @@ namespace PrintNode;
  * @property string $content
  * @property string $source
  * @property array $options
+ * @property int $expireAfter
+ * @property int $qty
+ * @property-read int $expireAt
  * @property-read int $filesize
  * @property-read DateTime $createTimestamp
  * @property-read string $state
@@ -26,11 +29,15 @@ class PrintJob extends Entity
     protected $contentType;
     protected $content;
     protected $source;
+    protected $options;
+    protected $expireAfter;
+    protected $qty;
+    protected $expireAt;
     protected $filesize;
     protected $createTimestamp;
     protected $state;
-    protected $expireAt;
-    protected $options;
+
+
 
     public function foreignKeyEntityMap()
     {


### PR DESCRIPTION
Allow the setting of qty and expireAfter properties as per the API: https://www.printnode.com/docs/api/curl/#printjob-creating. Order of parameters mirrored from API docs.